### PR TITLE
[kilted] Update deprecated call to ament_target_dependencies

### DIFF
--- a/examples/integration_test/CMakeLists.txt
+++ b/examples/integration_test/CMakeLists.txt
@@ -19,8 +19,8 @@ add_executable(integration_aux_node
   examples/integration_test/integration_aux_node.cpp
 )
 target_link_libraries(integration_aux_node PUBLIC
-  rclcpp
-  std_srvs
+  ${std_srvs_TARGETS}
+  rclcpp::rclcpp
 )
 
 install(TARGETS
@@ -42,10 +42,9 @@ if(BUILD_TESTING)
   # to get the default integration test node main function
   target_link_libraries(integration_test_node
     catch_ros2::catch_ros2_with_node_main
-  )
-  ament_target_dependencies(integration_test_node
-    rclcpp std_srvs
-  )
+    ${std_srvs_TARGETS}
+    rclcpp::rclcpp
+)
   install(TARGETS
     integration_test_node
     DESTINATION lib/${PROJECT_NAME}

--- a/examples/integration_test/CMakeLists.txt
+++ b/examples/integration_test/CMakeLists.txt
@@ -18,8 +18,9 @@ find_package(std_srvs REQUIRED)
 add_executable(integration_aux_node
   examples/integration_test/integration_aux_node.cpp
 )
-ament_target_dependencies(integration_aux_node
-  rclcpp std_srvs
+target_link_libraries(integration_aux_node PUBLIC
+  rclcpp
+  std_srvs
 )
 
 install(TARGETS


### PR DESCRIPTION
As of the ROS 2 Kilted release [`ament_target_dependencies` is deprecated.](https://docs.ros.org/en/kilted/Releases/Release-Kilted-Kaiju.html#ament-target-dependencies-is-deprecated)

This PR updates the syntax. Caution should be used to ensure that the target branch is not used for other ROS 2 distros.

Note: This PR was generated by a bot script, but using the simple pattern matching of the [`ros_glint`](https://github.com/MetroRobots/ros_glint) library. No LLMs were used.
