### PR TITLE
[kilted] Update deprecated call to ament_target_dependencies

### DIFF
--- a/examples/integration_test/CMakeLists.txt
+++ b/examples/integration_test/CMakeLists.txt
@@ -19,8 +19,8 @@ add_executable(integration_aux_node
   examples/integration_test/integration_aux_node.cpp
 )
 target_link_libraries(integration_aux_node PUBLIC
-  rclcpp
-  std_srvs
+  ${std_srvs_TARGETS}
+  rclcpp::rclcpp
 )
 
 install(TARGETS
@@ -42,10 +42,9 @@ if(BUILD_TESTING)
   # to get the default integration test node main function
   target_link_libraries(integration_test_node
     catch_ros2::catch_ros2_with_node_main
-  )
-  ament_target_dependencies(integration_test_node
-    rclcpp std_srvs
-  )
+    ${std_srvs_TARGETS}
+    rclcpp::rclcpp
+)
   install(TARGETS
     integration_test_node
     DESTINATION lib/${PROJECT_NAME}


### PR DESCRIPTION
Supersedes https://github.com/ngmor/catch_ros2/pull/14, see description there.